### PR TITLE
Add support for `wl-copy` and URI-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ Copy or install this plugin and add the following keymap to your `manager.prepen
 
 ```toml
 on = "<C-y>"
-run = ["plugin system-clipboard"]
+# Equivalent to `plugin system-clipboard file-list`
+run = "plugin system-clipboard"
+```
+
+```toml
+on = "<C-c>"
+run = "plugin system-clipboard content"
+```
+
+```toml
+on = "<C-l>"
+run = "plugin system-clipboard uri-list"
 ```
 
 > [!Tip]

--- a/main.lua
+++ b/main.lua
@@ -11,8 +11,110 @@ local selected_or_hovered = ya.sync(function()
 	return paths
 end)
 
+local function file_list_to_clipboard(urls, as_uri)
+	-- Format the URLs for `text/uri-list` specification
+	local function encode_uri(uri)
+		return uri:gsub("([^%w%-%._~:/])", function(c)
+			return string.format("%%%02X", string.byte(c))
+		end)
+	end
+
+	local file_list_formatted = ""
+	for _, path in ipairs(urls) do
+		if as_uri then
+			-- Each file path must be URI-encoded and prefixed with "file://"
+			file_list_formatted = file_list_formatted .. "file://" .. encode_uri(path) .. "\r\n"
+		else
+			file_list_formatted = file_list_formatted .. path .. "\n"
+		end
+	end
+
+	if as_uri then
+		-- Run either `cb` or `wl-copy` to copy the file list to the clipboard
+		local xdg_session_type = os.getenv("XDG_SESSION_TYPE")
+		if xdg_session_type == "wayland" then
+			-- We don't use `cb` here because of a critical bug as of v0.10.0, https://github.com/Slackadays/Clipboard/releases/tag/0.10.0.
+			-- Cf. also https://github.com/Slackadays/Clipboard/issues/171.
+			status, err = Command("wl-copy"):arg("--type"):arg("text/uri-list"):arg(file_list_formatted):spawn():wait()
+		elseif xdg_session_type == "x11" then
+			status, err = Command("cb"):arg("copy"):arg("--mime"):arg("text/uri-list"):arg(file_list_formatted):spawn():wait()
+		else
+			ya.notify({
+				title = "System Clipboard",
+				content = "`uri-list` not supported on your system",
+				level = "error",
+				timeout = 5,
+			})
+			return
+		end
+	else
+		ya.clipboard(file_list_formatted)
+		status = { success = true }
+	end
+
+	if status and status.success then
+		ya.notify({
+			title = "System Clipboard",
+			content = "Successfully copied the file(s) to system clipboard",
+			level = "info",
+			timeout = 2,
+		})
+	end
+
+	if not status or not status.success then
+		ya.notify({
+			title = "System Clipboard",
+			content = string.format("Could not copy selected file(s) %s", status and status.code or err),
+			level = "error",
+			timeout = 5,
+		})
+	end
+end
+
+local function content_to_clipboard(urls)
+	local content = ""
+	for _, url in ipairs(urls) do
+		local file = io.open(url, "r")
+		if file then
+			content = content .. file:read("*all") .. "\n"
+			file:close()
+		else
+			return ya.notify({
+				title = "System Clipboard",
+				content = string.format("Could not read file '%s'", url),
+				level = "error",
+				timeout = 5,
+			})
+		end
+
+	end
+	ya.clipboard(content)
+	ya.notify({
+		title = "System Clipboard",
+		content = "Content copied to clipboard",
+		level = "info",
+		timeout = 2,
+	})
+end
+
+--- @since 0.3.0
 return {
-	entry = function()
+	entry = function(_, job)
+		local action = job.args[1]
+		if not action then
+			action = "file-list"
+		end
+
+		-- Check if the action is valid.
+		if action ~= "file-list" and action ~= "uri-list" and action ~= "content" then
+			return ya.notify({
+				title = "System Clipboard",
+				content = string.format("Unknown action '%s'", action),
+				level = "error",
+				timeout = 5,
+			})
+		end
+
 		ya.manager_emit("escape", { visual = true })
 
 		local urls = selected_or_hovered()
@@ -21,34 +123,12 @@ return {
 			return ya.notify({ title = "System Clipboard", content = "No file selected", level = "warn", timeout = 5 })
 		end
 
-		-- ya.notify({ title = #urls, content = table.concat(urls, " "), level = "info", timeout = 5 })
-
-		local status, err =
-				Command("cb")
-				:arg("copy")
-				:args(urls)
-				:spawn()
-				:wait()
-
-		if status or status.succes then
-			ya.notify({
-				title = "System Clipboard",
-				content = "Succesfully copied the file(s) to system clipboard",
-				level = "info",
-				timeout = 5,
-			})
+		if action == "file-list" or action == "uri-list" then
+			file_list_to_clipboard(urls, action == "uri-list")
 		end
-
-		if not status or not status.success then
-			ya.notify({
-				title = "System Clipboard",
-				content = string.format(
-					"Could not copy selected file(s) %s",
-					status and status.code or err
-				),
-				level = "error",
-				timeout = 5,
-			})
+		if action == "content" then
+			content_to_clipboard(urls)
 		end
 	end,
 }
+


### PR DESCRIPTION
`cb` has issues on Wayland, cf. https://github.com/Slackadays/Clipboard/issues/171. Use `wl-copy` instead.

Allow three types of output:
- file list (the default and the unique possibility before this commit)
- URI list (credit goes to grappas)
- file content (doesn't work for binary files)

## Summary by Sourcery

Enable three clipboard output modes (file list, URI list, and file content), switch to `wl-copy` on Wayland to avoid `cb` issues, and enhance the plugin entry to accept and validate action arguments.

New Features:
- Add support for copying URI lists with percent-encoded file URIs
- Add support for copying file contents to the clipboard

Enhancements:
- Automatically choose `wl-copy` on Wayland and `cb` on X11 when copying URI lists
- Introduce a `file-list`, `uri-list`, or `content` action argument for the plugin entry point with validation and user notifications

Documentation:
- Update README with usage examples for `file-list`, `uri-list`, and `content` actions