### PR TITLE
Update deprecated Lua `args` to `arg`

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -23,17 +23,17 @@ return {
 
 		-- ya.notify({ title = #urls, content = table.concat(urls, " "), level = "info", timeout = 5 })
 
-		local status, err =
-				Command("cb")
-				:arg("copy")
-				:args(urls)
-				:spawn()
-				:wait()
+		local cmd = Command("cb"):arg("copy")
+		for _, url in ipairs(urls) do
+			cmd = cmd:arg(url)
+		end
 
-		if status or status.succes then
+		local status, err = cmd:spawn():wait()
+
+		if status and status.success then
 			ya.notify({
 				title = "System Clipboard",
-				content = "Succesfully copied the file(s) to system clipboard",
+				content = "Successfully copied the file(s) to system clipboard",
 				level = "info",
 				timeout = 5,
 			})
@@ -43,8 +43,8 @@ return {
 			ya.notify({
 				title = "System Clipboard",
 				content = string.format(
-					"Could not copy selected file(s) %s",
-					status and status.code or err
+					"Could not copy selected file(s): %s",
+					status and tostring(status.code) or tostring(err)
 				),
 				level = "error",
 				timeout = 5,


### PR DESCRIPTION
Fixes: #7 

- Replace deprecated .args(urls) with loop of individual .arg() calls
- Fix typos: 'succes' -> 'success', 'Succesfully' -> 'Successfully'
- Improve error handling logic and string formatting
- Resolves deprecation warnings in Yazi v0.4+

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Replace deprecated .args calls with per-argument .arg invocations, correct notification typos, and enhance error handling and formatting to resolve Yazi v0.4+ deprecation warnings.

Bug Fixes:
- Fix typo in success notification text ('succes' -> 'success')

Enhancements:
- Replace deprecated .args with multiple .arg calls to avoid deprecation warnings
- Improve error handling logic and format error notifications with proper string conversion