### PR TITLE
fix(main.lua): `ya.{manager_emit -> mgr_emit}`

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -13,7 +13,7 @@ end)
 
 return {
 	entry = function()
-		ya.manager_emit("escape", { visual = true })
+		ya.mgr_emit("escape", { visual = true })
 
 		local urls = selected_or_hovered()
 


### PR DESCRIPTION
`manager_emit` got deprecated in https://github.com/sxyazi/yazi/pull/2397 in favor of `ya.mgr_emit()`

## Summary by Sourcery

Bug Fixes:
- Replace deprecated ya.manager_emit with ya.mgr_emit in main.lua