### PR TITLE
fix: use ya.emit for yazi 25.x compatibility

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -13,7 +13,7 @@ end)
 
 return {
 	entry = function()
-		ya.mgr_emit("escape", { visual = true })
+		ya.emit("escape", { visual = true })
 
 		local urls = selected_or_hovered()
 


### PR DESCRIPTION
## Summary
- Replace `ya.mgr_emit` with `ya.emit` for compatibility with yazi 25.x API

## Test plan
- [x] Tested with yazi 25.x on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Replace deprecated ya.mgr_emit call with ya.emit to restore compatibility with yazi 25.x.