### PR TITLE
docs: readme update for yazi-26.1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ https://github.com/user-attachments/assets/74d59f49-266a-497e-b67e-d77e64209026
 
 ## Configuration
 
-Copy or install this plugin and add the following keymap to your `manager.prepend_keymap`:
+Copy or install this plugin and add the following keymap to your keymap.toml:
 
 ```toml
-on = "<C-y>"
-run = ["plugin system-clipboard"]
+[mgr]
+prepend_keymap = [
+	{on = "<C-y>", run = "plugin system-clipboard", desc = "Copy selected fiiles to system clipboard"}
+]
 ```
 
 > [!Tip]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Copy or install this plugin and add the following keymap to your keymap.toml:
 ```toml
 [mgr]
 prepend_keymap = [
-	{on = "<C-y>", run = "plugin system-clipboard", desc = "Copy selected fiiles to system clipboard"}
+	{on = "<C-y>", run = "plugin system-clipboard", desc = "Copy selected files to system clipboard"}
 ]
 ```
 


### PR DESCRIPTION
Existing keymap configuration on README was not working on latest version of yazi as of `21 Apr 2026`. 

So readme was modified to have a working keymap configuration.

## Summary by Sourcery

Documentation:
- Refresh README keymap example to use keymap.toml with the current yazi 26.1.22 configuration syntax.